### PR TITLE
fix(package): update xml deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "extend": "^1.3.0",
     "ldjson-stream": "^1.1.0",
     "minimist": "^0.2.0",
-    "pumpify": "^1.2.1",
-    "xml-nodes": "^0.1.2",
-    "xml-objects": "0.0.1"
+    "pumpify": "^1.3.5",
+    "xml-nodes": "^0.1.5",
+    "xml-objects": "^1.0.1"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
This PR updates the xml dependencies and pumpify which fixes issues with `gulp-awspublish`.

This package is used by [gulp-awspublish](https://github.com/pgherveou/gulp-awspublish) and is currently failing work with streams from S3.  Here is the stack trace where you can `xml-objects` is responsible for passing a bad stream down to `Duplexify`:

``` sh
TypeError: Cannot read property 'length' of undefined
    at Duplexify._forward (/home/ubuntu/ta-site/node_modules/duplexify/index.js:161:76)
    at XmlToObj.onreadable (/home/ubuntu/ta-site/node_modules/duplexify/index.js:126:10)
    at emitNone (events.js:86:13)
    at XmlToObj.emit (events.js:185:7)
    at emitReadable_ (_stream_readable.js:433:10)
    at emitReadable (_stream_readable.js:427:7)
    at readableAddChunk (_stream_readable.js:188:13)
    at XmlToObj.Readable.push (_stream_readable.js:135:10)
    at XmlToObj.Transform.push (_stream_transform.js:128:32)
    at /home/ubuntu/ta-site/node_modules/xml-objects/index.js:24:10
```

I spent all day tracing this down.  I noticed `xml-objects` was [refactored to use `through2` streams](https://github.com/timhudson/xml-objects/commit/e75e39723fffa3cd3f0c54f82549427f44e9f14f) and released as v1.  After updating dependencies here in `xml-json` and then forking and updating `gulp-awspublish` with this updated package, all is well.

Please merge the dep update here and make a release.  I can then go to `gulp-awspublish` and get a new release there as well.
